### PR TITLE
Add support for libvirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ This setup has been tested on Ubuntu 18.04 LTS and MacOS Catalina. The following
 ### Libvirt instead of VirtualBox
 
 It is also possible to use Libvirt/Qemu instead of VirtualBox. This requires:
-- vagrant
+- vagrant 2.0.2 or higher (FROM YOUR UBUNTU REPOSITORIES)
+- vagrant-libvirt (FROM YOUR UBUNTU REPOSITORIES)
 - libvirt
 
 Install Vagrant:
 
 ```bash
-apt install -y vagrant
+apt install -y vagrant vagrant-libvirt
 ```
 
 Then, use `Vagrantfile-libvirt` instead of `Vagrantfile`:
@@ -27,6 +28,8 @@ Then, use `Vagrantfile-libvirt` instead of `Vagrantfile`:
 mv Vagrantfile Vagrantfile-virtualbox
 cp Vagrantfile-libvirt Vagrantfile
 ```
+
+This has been tested on Ubuntu 18.04 LTS
 
 ## How to use
 After you installed the prerequisites you can start using the environment by following the steps underneath. If you want to jump straight into AWX click [here](#AWX).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ This setup has been tested on Ubuntu 18.04 LTS and MacOS Catalina. The following
 - virtualbox 6.0 (virtualbox 6.1 is currently not supported by Vagrant)
 - virtualbox extension pack (https://download.virtualbox.org/virtualbox/6.0.14/Oracle_VM_VirtualBox_Extension_Pack-6.0.14.vbox-extpack)
 
+### Libvirt instead of VirtualBox
+
+It is also possible to use Libvirt/Qemu instead of VirtualBox. This requires:
+- vagrant
+- libvirt
+
+Install Vagrant:
+
+```bash
+apt install -y vagrant
+```
+
+Then, use `Vagrantfile-libvirt` instead of `Vagrantfile`:
+
+```bash
+mv Vagrantfile Vagrantfile-virtualbox
+cp Vagrantfile-libvirt Vagrantfile
+```
+
 ## How to use
 After you installed the prerequisites you can start using the environment by following the steps underneath. If you want to jump straight into AWX click [here](#AWX).
 

--- a/Vagrantfile-libvirt
+++ b/Vagrantfile-libvirt
@@ -55,15 +55,14 @@ Vagrant.configure('2') do |config|
 
         # upload vagrant private key to awx
         machine.vm.provision "file", source: "~/.vagrant.d/insecure_private_key", destination: "$HOME/.ssh/id_rsa"
-   
-        # install ansible and setup prerequisites for AWX
-        machine.vm.provision "ansible_local", preserve_order: true do |ansible|
-            ansible.playbook = "provision/prerequisites_awx.yml"
-            ansible.install_mode = :pip
-            ansible.pip_install_cmd = "sudo yum install python3 python3-pip -y; sudo ln -s /usr/bin/pip3 /usr/bin/pip"
-            ansible.compatibility_mode = "2.0"
-        end
 
+        # Copy playbook to awx machine
+        machine.vm.provision "file", source: "provision/prerequisites_awx.yml", destination: "$HOME/prerequisites_awx.yml"
+
+        # Install requirements and run the ansible playbook
+        machine.vm.provision "shell", inline: "yum install python3 python3-pip -y; sudo ln -s /usr/bin/pip3 /usr/bin/pip", preserve_order: true
+        machine.vm.provision "shell", inline: "pip3 install ansible", preserve_order: true
+        machine.vm.provision "shell", inline: "ansible-playbook $HOME/prerequisites_awx.yml --extra-vars 'variable_host=localhost'", privileged: false, preserve_order: true
         # fix to reload new groups(docker)
         machine.vm.provision "shell", inline: "pkill -u vagrant sshd", preserve_order: true
         
@@ -79,13 +78,14 @@ Vagrant.configure('2') do |config|
             vb.memory = 2048
             vb.cpus = 1
         end
+
+        # Copy playbook to awx machine
+        machine.vm.provision "file", source: "provision/install_gitea.yml", destination: "$HOME/install_gitea.yml"
+
+        # Install requirements and run the ansible playbook
+        machine.vm.provision "shell", inline: "yum install python3 python3-pip -y; sudo ln -s /usr/bin/pip3 /usr/bin/pip", preserve_order: true
+        machine.vm.provision "shell", inline: "pip3 install ansible", preserve_order: true
+        machine.vm.provision "shell", inline: "ansible-playbook $HOME/install_gitea.yml --extra-vars 'variable_host=localhost'", privileged: false, preserve_order: true
    
-        # install ansible and setup prerequisites for AWX
-        machine.vm.provision "ansible_local", preserve_order: true do |ansible|
-            ansible.playbook = "provision/install_gitea.yml"
-            ansible.install_mode = :pip
-            ansible.pip_install_cmd = "sudo yum install python3 python3-pip -y; sudo ln -s /usr/bin/pip3 /usr/bin/pip"
-            ansible.compatibility_mode = "2.0"
-        end
     end
 end

--- a/Vagrantfile-libvirt
+++ b/Vagrantfile-libvirt
@@ -1,0 +1,91 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure('2') do |config|
+
+    # don't insert automatically generated keys on each host
+    # instead, use the default "insecure" key, so the nodes can
+    # communicate with the same ssh key
+    config.ssh.insert_key = false
+
+    # set default settings
+    config.vm.box = "centos/7"
+    config.vm.provider "libvirt" do |vb|
+        vb.memory = 1024
+        vb.cpus = 1
+    end
+
+    config.vm.define :ansible, primary: true do |machine|
+        machine.vm.host_name = "ansible.local"
+        machine.vm.network "private_network", ip: "192.168.50.10"
+
+        machine.vm.provider "libvirt" do |vb|
+            vb.memory = 2048
+            vb.cpus = 2
+        end
+
+        # install ansible
+        machine.vm.provision "shell", path: "provision/install_ansible.sh"
+
+        # sync ansible to /home/vagrant/ansible
+        machine.vm.synced_folder "ansible/", "/home/vagrant/ansible"
+
+        # upload vagrant private key to ansible controller
+        machine.vm.provision "file", source: "~/.vagrant.d/insecure_private_key", destination: "$HOME/.ssh/id_rsa"
+    end
+
+    config.vm.define :node1 do |machine|
+        machine.vm.host_name = "node1.local"
+        machine.vm.network "private_network", ip: "192.168.50.12"
+    end
+
+    config.vm.define :node2 do |machine|
+        machine.vm.host_name = "node2.local"
+        machine.vm.network "private_network", ip: "192.168.50.13"
+    end
+
+    config.vm.define :awx, autostart: false do |machine|
+        machine.vm.host_name = "awx.local"
+        machine.vm.network "private_network", ip: "192.168.50.11"
+
+        machine.vm.provider "libvirt" do |vb|
+            vb.memory = 4096
+            vb.cpus = 2
+        end
+
+        # upload vagrant private key to awx
+        machine.vm.provision "file", source: "~/.vagrant.d/insecure_private_key", destination: "$HOME/.ssh/id_rsa"
+   
+        # install ansible and setup prerequisites for AWX
+        machine.vm.provision "ansible_local", preserve_order: true do |ansible|
+            ansible.playbook = "provision/prerequisites_awx.yml"
+            ansible.install_mode = :pip
+            ansible.pip_install_cmd = "sudo yum install python3 python3-pip -y; sudo ln -s /usr/bin/pip3 /usr/bin/pip"
+            ansible.compatibility_mode = "2.0"
+        end
+
+        # fix to reload new groups(docker)
+        machine.vm.provision "shell", inline: "pkill -u vagrant sshd", preserve_order: true
+        
+        # install awx using the provided playbook
+        machine.vm.provision "shell", path: "provision/install_awx.sh", privileged: false, preserve_order: true
+    end
+
+    config.vm.define :gitea, autostart: false do |machine|
+        machine.vm.host_name = "gitea.local"
+        machine.vm.network "private_network", ip: "192.168.50.15"
+
+        machine.vm.provider "libvirt" do |vb|
+            vb.memory = 2048
+            vb.cpus = 1
+        end
+   
+        # install ansible and setup prerequisites for AWX
+        machine.vm.provision "ansible_local", preserve_order: true do |ansible|
+            ansible.playbook = "provision/install_gitea.yml"
+            ansible.install_mode = :pip
+            ansible.pip_install_cmd = "sudo yum install python3 python3-pip -y; sudo ln -s /usr/bin/pip3 /usr/bin/pip"
+            ansible.compatibility_mode = "2.0"
+        end
+    end
+end

--- a/provision/install_gitea.yml
+++ b/provision/install_gitea.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: gitea
+- hosts: "{{ variable_host | default('gitea') }}"
   become: yes
   become_method: sudo
   gather_facts: True

--- a/provision/prerequisites_awx.yml
+++ b/provision/prerequisites_awx.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: awx
+- hosts: "{{ variable_host | default('awx') }}"
   become: yes
   become_method: sudo
   tasks:


### PR DESCRIPTION
- Update README to facilitate libvirt usage
- Add Vagrantfile-libvirt

This new vagrantfile differs from the original:
- Use centos/7 instead of bento/centos-7